### PR TITLE
Documentation fixes and minor improvement to a utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ the `RestAuth.Handler` behaviour. An example handler is provided in the
 You also need to set up an authentication controller of sorts that calls
 `RestAuth.Controller.login/3` and `RestAuth.Controller.logout/3` functions
 
-A typical sample usage in a controller looks like so (pulled from `Restauth.Restrict` documentation):
+A typical sample usage in a controller looks like so (pulled from `RestAuth.Restrict` documentation):
 
     @rest_auth_roles  [
       {:index, ["user"]},
@@ -49,10 +49,10 @@ The handler module provided by the user takes full responsibility for loading
 user data from the database and caching the data using `RestAuth.CacheService`
 if caching is required.
 
-This library aims to be a slightly oppinionated framework for you to build your
+This library aims to be a slightly opinionated framework for you to build your
 own logic on top of. After having implemented the behaviour `RestAuth` should
-rarely get in the way of anyhting.
-  
+rarely get in the way of anything.
+
 ## State of the project
 
 The project is used in production. That said there are couple things that

--- a/lib/rest_auth.ex
+++ b/lib/rest_auth.ex
@@ -18,7 +18,7 @@ defmodule RestAuth do
   You also need to set up an authentication controller of sorts that calls
   `RestAuth.Controller.login/3` and `RestAuth.Controller.logout/3` functions
 
-  A typical sample usage in a controller looks like so (pulled from `Restauth.Restrict` documentation):
+  A typical sample usage in a controller looks like so (pulled from `RestAuth.Restrict` documentation):
 
       @rest_auth_roles  [
         {:index, ["user"]},
@@ -33,9 +33,9 @@ defmodule RestAuth do
   user data from the database and caching the data using `RestAuth.CacheService`
   if caching is required.
 
-  This library aims to be a slightly oppinionated framework for you to build your
+  This library aims to be a slightly opinionated framework for you to build your
   own logic on top of. After having implemented the behaviour `RestAuth` should
-  rarely get in the way of anyhting.
+  rarely get in the way of anything.
   """
   use Application
 

--- a/lib/rest_auth/authority.ex
+++ b/lib/rest_auth/authority.ex
@@ -34,10 +34,11 @@ defmodule RestAuth.Authority do
   silently dropped.
   """
   def from_binary_key_map(map) do
-    binary_keys = Map.keys(%RestAuth.Authority{})
+    default_authority = %RestAuth.Authority{}
+    binary_keys = Map.keys(default_authority)
                   |> Enum.map(&Atom.to_string(&1))
     Map.take(map, binary_keys)
-    |> Enum.reduce(%RestAuth.Authority{}, fn {k,v}, acc ->
+    |> Enum.reduce(default_authority, fn {k,v}, acc ->
       Map.put(acc, String.to_existing_atom(k), v)
     end)
   end

--- a/lib/rest_auth/cache_service.ex
+++ b/lib/rest_auth/cache_service.ex
@@ -2,7 +2,7 @@ defmodule RestAuth.CacheService do
   @moduledoc """
   Generic caching service to be used by the user implemented handler module.
 
-  Most functions from the handler, should use the cache service for best
+  Most functions from the handler should use the cache service for best
   performance and behaviour.
 
   The data is cached in ETS tables. The service expects a homogeneous

--- a/lib/rest_auth/plug_authenticate.ex
+++ b/lib/rest_auth/plug_authenticate.ex
@@ -2,7 +2,7 @@ defmodule RestAuth.Authenticate do
   @moduledoc """
   `RestAuth.Authenticate` is used to load user information into conn.
 
-  It will use the configured handler, to load the authority struct and
+  It will use the configured handler to load the authority struct and
   store it in the connection. The user data can be later accessed using
   functions from `RestAuth.Utility` module.
 

--- a/test/rest_auth/authority_test.exs
+++ b/test/rest_auth/authority_test.exs
@@ -1,0 +1,14 @@
+defmodule RestAuth.AuthorityTest do
+  use ExUnit.Case, async: true
+
+  alias RestAuth.Authority
+
+  describe "authority" do
+    test "from binary key map" do
+      map = %{"token" => "abc", "unwanted" => "should be dropped"}
+      authority = Authority.from_binary_key_map(map)
+      assert authority == %Authority{token: "abc"}
+      refute Map.get(authority, :unwanted, false)
+    end
+  end
+end


### PR DESCRIPTION
When scanning through the library I noticed a few typos in documentation and one other quick improvement (`Authority.from_binary_key_map/1` was needlessly making a default authority struct twice).