### PR TITLE
Add ErrorHandler to permit customization of Plug error responses

### DIFF
--- a/lib/rest_auth/error_handler.ex
+++ b/lib/rest_auth/error_handler.ex
@@ -1,0 +1,59 @@
+defmodule RestAuth.ErrorHandler do
+  @moduledoc """
+  Behaviour for providing overridable error handling for RestAuth plugs.
+
+  Set in config like:
+  ```elixir
+  config :rest_auth,
+    error_handler: YourErrorHandler
+  ```
+  """
+
+  alias Plug.Conn
+
+  import Plug.Conn
+
+  @doc """
+  Triggered when there is an error authenticating a client.
+
+  Used in:
+    `RestAuth.Authenticate`.
+  """
+  @callback cannot_authenticate(conn :: Conn.t(), reason :: any, from_cookie? :: boolean) :: Conn.t()
+
+  @doc """
+  Triggered when a client is unauthenticated.
+
+  Used in:
+    `RestAuth.Restrict`.
+  """
+  @callback unauthenticated(conn :: Conn.t()) :: Conn.t()
+
+  @doc """
+  Triggered when a client is unauthorized.
+
+  Used in:
+    `RestAuth.Restrict`.
+  """
+  @callback unauthorized(conn :: Conn.t()) :: Conn.t()
+
+  # Helpers
+
+  @doc """
+  Returns the ErrorHandler set in config, or the provided default.
+  """
+  def from_config_or(default) do
+    Application.get_env(:rest_auth, :error_handler, default)
+  end
+
+  @doc """
+  Deletes the `x-auth-token` cookie.
+
+  For use when an invalid token is provided by a cookie.
+  """
+  def clean_cookie(conn, true) do
+    put_resp_cookie(conn, "x-auth-token", "deleted")
+  end
+
+  def clean_cookie(conn, false), do: conn
+end

--- a/lib/rest_auth/error_handler.ex
+++ b/lib/rest_auth/error_handler.ex
@@ -2,9 +2,11 @@ defmodule RestAuth.ErrorHandler do
   @moduledoc """
   Behaviour for providing overridable error handling for RestAuth plugs.
 
-  Set in config like:
-  ```elixir
-  config :rest_auth,
+  Configured with `RestAuth.Configure` like:
+
+  ```
+  plug RestAuth.Configure,
+    handler: YourHandler,
     error_handler: YourErrorHandler
   ```
   """
@@ -40,10 +42,13 @@ defmodule RestAuth.ErrorHandler do
   # Helpers
 
   @doc """
-  Returns the ErrorHandler set in config, or the provided default.
+  Returns the ErrorHandler from the conn, or raises.
   """
-  def from_config_or(default) do
-    Application.get_env(:rest_auth, :error_handler, default)
+  def fetch!(%Conn{} = conn) do
+    case Map.fetch(conn.private, :rest_auth_error_handler) do
+      {:ok, error_handler} -> error_handler
+      :error -> raise "Unable to fetch the error handler- has the `RestAuth.Configure` plug been used?"
+    end
   end
 
   @doc """

--- a/lib/rest_auth/error_handler/default.ex
+++ b/lib/rest_auth/error_handler/default.ex
@@ -1,0 +1,33 @@
+defmodule RestAuth.ErrorHandler.Default do
+  @behaviour RestAuth.ErrorHandler
+  @moduledoc """
+  Default implementation of `RestAuth.ErrorHandler`.
+  """
+
+  alias RestAuth.ErrorHandler
+
+  import Plug.Conn
+  import Phoenix.Controller, only: [json: 2]
+
+  def cannot_authenticate(conn, reason, from_cookie?) do
+    conn
+    |> ErrorHandler.clean_cookie(from_cookie?)
+    |> put_status(401)
+    |> json(%{"error" => reason})
+    |> halt()
+  end
+
+  def unauthenticated(conn) do
+    conn
+    |> put_status(401)
+    |> json(%{"error" => "not authenticated"})
+    |> halt()
+  end
+
+  def unauthorized(conn) do
+    conn
+    |> put_status(403)
+    |> json(%{"error" => "you do not have access to this resource"})
+    |> halt()
+  end
+end

--- a/lib/rest_auth/plug_authenticate.ex
+++ b/lib/rest_auth/plug_authenticate.ex
@@ -56,7 +56,7 @@ defmodule RestAuth.Authenticate do
 
           # All error conditions will halt the plug pipeline
           {:error, reason} ->
-            error_handler = ErrorHandler.from_config_or(ErrorHandler.Default)
+            error_handler = ErrorHandler.fetch!(conn)
 
             error_handler.cannot_authenticate(conn, reason, from_cookie?)
             |> halt() # Ensure halted

--- a/lib/rest_auth/plug_configure.ex
+++ b/lib/rest_auth/plug_configure.ex
@@ -4,22 +4,39 @@ defmodule RestAuth.Configure do
 
   Most other plug-related functionality like `RestAuth.Controller` functions
   or `RestAuth.Restrict` plug require the configure plug to be applied earlier.
+
+  A `:handler` must be provided, while an `:error_handler` may optionally be
+  provided.
   """
 
   @behaviour Plug
 
+  alias RestAuth.ErrorHandler
+
   def init(opts) do
-    Keyword.fetch!(opts, :handler)
+    handler = Keyword.fetch!(opts, :handler)
+    error_handler = Keyword.get(opts, :error_handler, ErrorHandler.Default)
+    {handler, error_handler}
   end
 
-  def call(conn, handler) do
+  def call(conn, {handler, error_handler}) do
     case conn.private do
-      %{rest_auth_handler: ^handler} ->
+      %{rest_auth_handler: ^handler, rest_auth_error_handler: ^error_handler} ->
         conn
-      %{rest_auth_handler: other} ->
+
+      %{rest_auth_handler: other, rest_auth_error_handler: ^error_handler} ->
         raise ArgumentError, "conflicting `:rest_auth_handler` found: #{inspect other} while trying to configure #{inspect handler}"
+
+      %{rest_auth_handler: ^handler, rest_auth_error_handler: other} ->
+        raise ArgumentError, "conflicting `:rest_auth_handler` found: #{inspect other} while trying to configure #{inspect handler}"
+
+      %{rest_auth_handler: other_h, rest_auth_error_handler: other_eh} ->
+        raise ArgumentError, "conflicting `:rest_auth_handler` and `:rest_auth_error_handler` found: #{inspect(other_h)} and #{inspect(other_eh)} while trying to configure #{inspect(handler)} and #{inspect(error_handler)}"
+
       _ ->
-        Plug.Conn.put_private(conn, :rest_auth_handler, handler)
+        conn
+        |> Plug.Conn.put_private(:rest_auth_handler, handler)
+        |> Plug.Conn.put_private(:rest_auth_error_handler, error_handler)
     end
   end
 end

--- a/lib/rest_auth/plug_restrict.ex
+++ b/lib/rest_auth/plug_restrict.ex
@@ -60,13 +60,13 @@ defmodule RestAuth.Restrict do
         conn
 
       RestAuth.Utility.is_anonymous?(conn) ->
-        error_handler = ErrorHandler.from_config_or(ErrorHandler.Default)
+        error_handler = ErrorHandler.fetch!(conn)
 
         error_handler.unauthenticated(conn)
         |> halt() # Ensure halted
 
       true ->
-        error_handler = ErrorHandler.from_config_or(ErrorHandler.Default)
+        error_handler = ErrorHandler.fetch!(conn)
 
         error_handler.unauthorized(conn)
         |> halt() # Ensure halted


### PR DESCRIPTION
Error responses for `RestAuth` plugs were previously hard-coded and impossible to customize.

This PR adds a `RestAuth.ErrorHandler` behaviour, a default implementation of the behaviour that returns the same errors as were hard-coded before, and uses this error handler to respond to errors in `RestAuth.Authenticate` and `RestAuth.Restrict`. 

  - Add RestAuth.ErrorHandler behaviour
  - Add RestAuth.ErrorHandler.Default implementation
  - Update RestAuth.Authenticate and RestAuth.Restrict to use ErrorHandler